### PR TITLE
FlameTankHook: add 'info' in passed args (RDEV-7471)

### DIFF
--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -150,4 +150,4 @@ def customUIAction(info, userData):
         # RDO: Launcher should have added the Flame workgroup to the PYTHONPATH, so we should
         # be able to run the custom actions from the workgroup.
         import rodeo_hook
-        rodeo_hook.customUIAction(userData)
+        rodeo_hook.customUIAction(info, userData)


### PR DESCRIPTION
**Purpose of the PR / What does this do?**
When using tank, the flame hooks gets overwritten, and info isn't passed to rodeo_hook.customUIAction()
This results in the flame shotgun playlist importer to fail. We added the 'info' in the args
 
**Overview of the changes (don't assume any history)**
Add 'info' in  rodeo_hook.customUIAction()

**Type of feedback wanted**
minimal 

**Where should the reviewer start looking at?**
any place 

**Potential risks of this change, if any.**
none 

**Relationship with other PRs (with links!)**
none